### PR TITLE
Added country parameter to iTunes lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ This is the application bundle ID, used to retrieve the latest version and relea
     
 This is the language localisation that will be specified when retrieving release notes from iTunes. This is set automatically from the device language preferences, so shouldn't need to be changed.
 
+    @property (nonatomic, copy) NSString *appStoreCountry;
+
+This is the country in which to look for the latest version and release notes. The default is US. You should only have to change this if your application is not distributed on the US AppStore.
+
 	@property (nonatomic, assign) BOOL showOnFirstLaunch;
 
 Specify whether the release notes for the current version should be shown the first time the user launches the app. If set to no it means that users who, for example, download version 1.1 of your app but never installed a previous version, won't be shown the new features in version 1.1.

--- a/iVersion/iVersion.h
+++ b/iVersion/iVersion.h
@@ -133,6 +133,7 @@
     NSString *applicationVersion;
     NSString *applicationBundleID;
     NSString *appStoreLanguage;
+    NSString *appStoreCountry;
     BOOL showOnFirstLaunch;
     BOOL groupNotesByVersion;
     float checkPeriod;
@@ -169,6 +170,7 @@
 @property (nonatomic, copy) NSString *applicationVersion;
 @property (nonatomic, copy) NSString *applicationBundleID;
 @property (nonatomic, copy) NSString *appStoreLanguage;
+@property (nonatomic, copy) NSString *appStoreCountry;
 
 //usage settings - these have sensible defaults
 @property (nonatomic, assign) BOOL showOnFirstLaunch;

--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -107,6 +107,7 @@ NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.apple.com/
 @synthesize applicationVersion;
 @synthesize applicationBundleID;
 @synthesize appStoreLanguage;
+@synthesize appStoreCountry;
 @synthesize showOnFirstLaunch;
 @synthesize groupNotesByVersion;
 @synthesize checkPeriod;
@@ -289,6 +290,7 @@ NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.apple.com/
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     
     AH_RELEASE(appStoreLanguage);
+    AH_RELEASE(appStoreCountry);
     AH_RELEASE(remoteVersionsDict);
     AH_RELEASE(downloadError);
     AH_RELEASE(remoteVersionsPlistURL);
@@ -589,6 +591,9 @@ NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.apple.com/
 
             //first check iTunes
             NSString *iTunesServiceURL = [NSString stringWithFormat:iTunesLookupURLFormat, appStoreLanguage];
+            if (appStoreCountry) {
+                iTunesServiceURL = [iTunesServiceURL stringByAppendingFormat:@"&country=%@", appStoreCountry];
+            }
             if (appStoreID)
             {
                 iTunesServiceURL = [iTunesServiceURL stringByAppendingFormat:@"&id=%i", appStoreID];


### PR DESCRIPTION
I added the country parameter to the iTunes lookup URL - the default US country didn't allow me to check on applications available exclusively outside the US.
