### PR TITLE
Fixed stack overflow when -(NSString *)versionDetails calls itself.

### DIFF
--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -431,7 +431,7 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
 
 - (NSString *)versionDetails
 {
-    if (!self.versionDetails)
+    if (!_versionDetails)
     {
         if (self.viewedVersionDetails)
         {
@@ -442,7 +442,7 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
             self.versionDetails = [self versionDetailsSince:self.lastVersion inDict:[self localVersionsDict]];
         }
     }
-    return self.versionDetails;
+    return _versionDetails;
 }
 
 - (NSString *)URLEncodedString:(NSString *)string


### PR DESCRIPTION
Fixes a stack overflow introduced in https://github.com/nicklockwood/iVersion/commit/6699d01da38ab52579ff0e4de3e7cb0bcab4095e
