### PR TITLE
Fixed a problem with NSMutableDictionary handling

### DIFF
--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -879,14 +879,15 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
                             if (latestVersion)
                             {
                                 //remove versions that are greater than latest in app store
-                                plistVersions = [plistVersions mutableCopy];
-                                for (NSString *version in [plistVersions keyEnumerator])
+                                NSMutableDictionary *newPlistVersions = [NSMutableDictionary new];
+                                for (NSString *version in plistVersions)
                                 {
-                                    if ([version compareVersion:latestVersion] == NSOrderedDescending)
+                                    if ([version compareVersion:latestVersion] != NSOrderedDescending)
                                     {
-                                        [(NSMutableDictionary *)plistVersions removeObjectForKey:version];
+                                        [newPlistVersions setObject:[plistVersions objectForKey:version] forKey:version];
                                     }
                                 }
+                                plistVersions = (NSDictionary *)newPlistVersions;
                             }
                             if (!latestVersion || plistVersions[latestVersion] || !_useAppStoreDetailsIfNoPlistEntryFound)
                             {


### PR DESCRIPTION
I found a bug when iVersion removes future versions of the app from the release notes plist.  At least on iOS (maybe OSX too?), an NSMutableDictionary can't be modified while being enumerated.  I rewrote the loop so that it creates a new NSMutableDictionary and copies the needed data over from the existing dictionary instead.

Thanks,
Curtis
