### PR TITLE
Use -[UIApplication keyWindow] instead of delegate window

### DIFF
--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -1022,7 +1022,7 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
         [productController loadProductWithParameters:productParameters completionBlock:NULL];
         
         //get root view controller
-        UIWindow *window = [[UIApplication sharedApplication] delegate].window;
+        UIWindow *window = [UIApplication sharedApplication].keyWindow;
         UIViewController *rootViewController = window.rootViewController;
         if (!rootViewController)
         {


### PR DESCRIPTION
`UIApplicationDelegate` protocol doesn't have a window method, it's common convention that it has a property called window. However it is not enforced.
