### PR TITLE
Fix an issue when the version detail string to append is nil

### DIFF
--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -415,7 +415,7 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
                 [details appendString:[self.versionLabelFormat stringByReplacingOccurrencesOfString:@"%@" withString:version]];
                 [details appendString:@"\n\n"];
             }
-            [details appendString:[self versionDetails:version inDict:dict]];
+            [details appendString:[self versionDetails:version inDict:dict] ?: @""];
             [details appendString:@"\n"];
             if (self.groupNotesByVersion)
             {


### PR DESCRIPTION
To avoid `NSInvalidArgumentException` when `versionDetails:inDict:` returns nil.
