### PR TITLE
Added support for iVersionMenuOptionTypeOption

### DIFF
--- a/iVersion/iVersion.h
+++ b/iVersion/iVersion.h
@@ -69,13 +69,18 @@ static NSString *const iVersionIgnoreButtonKey = @"iVersionIgnoreButton";
 static NSString *const iVersionRemindButtonKey = @"iVersionRemindButton";
 static NSString *const iVersionDownloadButtonKey = @"iVersionDownloadButton";
 
-
-typedef enum
-{
+typedef NS_ENUM(NSUInteger, iVersionErrorCode) {
+    
     iVersionErrorBundleIdDoesNotMatchAppStore = 1,
     iVersionErrorApplicationNotFoundOnAppStore
-}
-iVersionErrorCode;
+};
+
+typedef NS_ENUM(NSInteger, iVersionMenuOptionType) {
+    
+    iVersionMenuOptionTypeForce,
+    iVersionMenuOptionTypeOption,
+    iVersionMenuOptionTypeSkip,
+};
 
 
 @interface NSString(iVersion)
@@ -117,6 +122,8 @@ iVersionErrorCode;
 @property (nonatomic, copy) NSString *applicationVersion;
 @property (nonatomic, copy) NSString *applicationBundleID;
 @property (nonatomic, copy) NSString *appStoreCountry;
+@property (nonatomic, readwrite) iVersionMenuOptionType menuOptionType;
+
 
 //usage settings - these have sensible defaults
 @property (nonatomic, assign) BOOL showOnFirstLaunch;

--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -198,6 +198,7 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
         self.applicationBundleID = [[NSBundle mainBundle] bundleIdentifier];
         
         //default settings
+        self.menuOptionType = iVersionMenuOptionTypeOption;
         self.useAllAvailableLanguages = YES;
         self.onlyPromptIfMainWindowIsAvailable = YES;
         self.checkAtLaunch = YES;
@@ -605,14 +606,40 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
                     title = [title stringByAppendingFormat:@" (%@)", mostRecentVersion];
                 }
                 
-                self.visibleRemoteAlert = [self alertViewWithTitle:title
-                                                           details:details
-                                                     defaultButton:self.downloadButtonLabel
-                                                      cancelButton:self.ignoreButtonLabel];
-                
-                if ([self.remindButtonLabel length])
-                {
-                    [self.visibleRemoteAlert addButtonWithTitle:self.remindButtonLabel];
+                switch (self.menuOptionType) {
+                    
+                    case iVersionMenuOptionTypeForce:
+                        
+                        self.visibleRemoteAlert = [self alertViewWithTitle:title
+                                                                   details:details
+                                                             defaultButton:self.downloadButtonLabel
+                                                              cancelButton:nil];
+                        break;
+                        
+                    case iVersionMenuOptionTypeOption:
+                    {
+                        
+                        self.visibleRemoteAlert = [self alertViewWithTitle:title
+                                                                   details:details
+                                                             defaultButton:self.downloadButtonLabel
+                                                              cancelButton:self.ignoreButtonLabel];
+                        
+                        [self conditionallyAddRemindButton];
+                        
+                        break;
+                    }
+                        
+                    case iVersionMenuOptionTypeSkip:
+                    {
+                        self.visibleRemoteAlert = [self alertViewWithTitle:title
+                                                                   details:details
+                                                             defaultButton:self.downloadButtonLabel
+                                                              cancelButton:nil];
+                        [self conditionallyAddRemindButton];
+                        
+                        break;
+                    }
+                        
                 }
                 
 #if TARGET_OS_IPHONE
@@ -631,6 +658,14 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
         {
             [self.delegate iVersionDidNotDetectNewVersion];
         }
+    }
+}
+
+- (void) conditionallyAddRemindButton
+{
+    if ([self.remindButtonLabel length])
+    {
+        [self.visibleRemoteAlert addButtonWithTitle:self.remindButtonLabel];
     }
 }
 


### PR DESCRIPTION
Don't know if you are interested in adding support for different types of configurations on alertView, like, forcing the user only to update, or giving him options instead: iVersionMenuOptionType - just like Harpy does

I've also changed your existing enum to use typedef NS_ENUM to be consistent.

Kept your codestyle.
