### PR TITLE
Fix Gibraltar as appStoreCountry

### DIFF
--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -181,6 +181,10 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
         {
             self.appStoreCountry = @"us";
         }
+        else if ([self.appStoreCountry isEqualToString:@"GI"])
+        {
+            self.appStoreCountry = @"GB";
+        }
         
         //application version (use short version preferentially)
         self.applicationVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];


### PR DESCRIPTION
Check if the country is GI (Gibraltar) to redirect to GB because Gibraltar doesn't have app store country