### PR TITLE
- Updated https link for ATS support.

### DIFF
--- a/iVersion/iVersion.m
+++ b/iVersion/iVersion.m
@@ -68,7 +68,7 @@ static NSString *const iVersionLastCheckedKey = @"iVersionLastChecked";
 static NSString *const iVersionLastRemindedKey = @"iVersionLastReminded";
 
 static NSString *const iVersionMacAppStoreBundleID = @"com.apple.appstore";
-static NSString *const iVersionAppLookupURLFormat = @"http://itunes.apple.com/%@/lookup";
+static NSString *const iVersionAppLookupURLFormat = @"https://itunes.apple.com/%@/lookup";
 
 static NSString *const iVersioniOSAppStoreURLFormat = @"itms-apps://itunes.apple.com/app/id%@";
 static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.apple.com/app/id%@";


### PR DESCRIPTION
Just in case to make sure that https://itunes.apple.com/ link satisfies ATS I have checked in terminal and it got the following certificate details of that link

curl -vI https://itunes.apple.com
* Connected to itunes.apple.com (118.214.130.217) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384